### PR TITLE
Explicit override methods

### DIFF
--- a/src/GribApi.NET/Grib.Api/GeoCoordinate.cs
+++ b/src/GribApi.NET/Grib.Api/GeoCoordinate.cs
@@ -69,9 +69,9 @@ namespace Grib.Api
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
+        public override bool Equals (object obj)
         {
-            return (obj is GeoCoordinate) && Equals((GeoCoordinate)obj);
+            return (obj is GeoCoordinate) && this.Equals((GeoCoordinate)obj);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Grib.Api
         /// </returns>
         public override int GetHashCode()
         {
-            return Latitude.GetHashCode() ^ Longitude.GetHashCode();
+            return this.Latitude.GetHashCode() ^ this.Longitude.GetHashCode();
         }
 
         /// <summary>

--- a/src/GribApi.NET/Grib.Api/GeoCoordinate.cs
+++ b/src/GribApi.NET/Grib.Api/GeoCoordinate.cs
@@ -23,7 +23,7 @@ namespace Grib.Api
     /// <summary>
     /// A geospatial coordinate.
     /// </summary>
-    public struct GeoCoordinate : IGeoCoordinate
+    public struct GeoCoordinate : IGeoCoordinate, IEquatable<GeoCoordinate>
     {
         /// <summary>
         /// Gets or sets the latitude for this coordinate.
@@ -60,6 +60,29 @@ namespace Grib.Api
         {
             return (this.Latitude == that.Latitude) &&
                    (this.Longitude == that.Longitude);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is GeoCoordinate) && Equals((GeoCoordinate)obj);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return Latitude.GetHashCode() ^ Longitude.GetHashCode();
         }
 
         /// <summary>

--- a/src/GribApi.NET/Grib.Api/GeoSpatialValue.cs
+++ b/src/GribApi.NET/Grib.Api/GeoSpatialValue.cs
@@ -18,7 +18,7 @@ namespace Grib.Api
     /// <summary>
     /// A GRIB grid value with coordinates.
     /// </summary>
-    public struct GeoSpatialValue : IGeoCoordinate
+    public struct GeoSpatialValue : IGeoCoordinate, IEquatable<GeoSpatialValue>
     {
         public double Latitude { get; set; }
         public double Longitude { get; set; }
@@ -44,6 +44,29 @@ namespace Grib.Api
                 (this.Longitude == that.Longitude) && 
                 (this.Value == that.Value);
         }
+
+          /// <summary>
+          /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+          /// </summary>
+          /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+          /// <returns>
+          ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+          /// </returns>
+          public override bool Equals (object obj)
+          {
+              return (obj is GeoSpatialValue) && this.Equals((GeoSpatialValue)obj);
+          }
+ 
+          /// <summary>
+          /// Returns a hash code for this instance.
+          /// </summary>
+          /// <returns>
+          /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+          /// </returns>
+          public override int GetHashCode()
+          {
+              return this.Latitude.GetHashCode() ^ this.Longitude.GetHashCode() ^ this.Value.GetHashCode();
+          }
 
         /// <summary>
         /// Implements the operator ==.


### PR DESCRIPTION
Explicit override GetHashCode and Equals(object) for GeoCoordinate and GeoSpatialValue instead of relying of autogenerated ones. 
This benefits performance, even though I haven't done any real world benchmarks myself.